### PR TITLE
Set up GO modules.  Document some functions.

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,13 +27,15 @@ GoFBP Network Definition Syntax and Component API:
 
 ## Tracing
 
-An XML file has been provided in the root, called `params.xml`.  So far there is only one parameter:
-
-<pre>
-&lt;?xml version="1.0"?&gt;
-&lt;tracing&gt;true|false&lt;/tracing&gt;
-&lt;tracelocks&gt;true|false&lt;/tracelocks&gt;
-</pre>
+An XML file has been provided in the root, called `params.xml`:
+```
+<?xml version="1.0"?> 
+<runparams>
+<tracing>false</tracing>
+<tracelocks>false</tracelocks>
+<generate-gIds>false</generate-gIds> 
+</runparams>
+```
 
 ## Subnets
 These are described in Chap. 7 in "Flow-Based Programming": Composite Components - https://jpaulmorrison.com/fbp/compos.shtml , although we haven't implemented dynamic subnets (yet)!
@@ -140,4 +142,5 @@ The following components are available:
 - Add Load Balancing component
 - Add sample code showing use of substreams
 - "Automatic" ports - *done!*
-- Add Lua interface - see https://jpaulm.github.io/fbp/thlua.html
+- Add Lua interface - see https://jpaulm.github.io/fbp/thlua.html 
+

--- a/components/io/go.mod
+++ b/components/io/go.mod
@@ -1,0 +1,3 @@
+module gofbp/components/io
+
+go 1.16

--- a/components/io/readfile.go
+++ b/components/io/readfile.go
@@ -1,3 +1,4 @@
+/*Package io implements gofbp I/O*/
 package io
 
 import (

--- a/components/io/writefile.go
+++ b/components/io/writefile.go
@@ -8,13 +8,13 @@ import (
 )
 
 type WriteFile struct {
-	iptIp core.InputConn
+	iptIP core.InputConn
 	ipt   core.InputConn
 	opt   core.OutputConn
 }
 
 func (writeFile *WriteFile) Setup(p *core.Process) {
-	writeFile.iptIp = p.OpenInPort("FILENAME")
+	writeFile.iptIP = p.OpenInPort("FILENAME")
 	writeFile.ipt = p.OpenInPort("IN")
 	writeFile.opt = p.OpenOutPortOptional("OUT")
 }
@@ -23,13 +23,13 @@ func (WriteFile) MustRun() {}
 
 func (writeFile *WriteFile) Execute(p *core.Process) {
 
-	icpkt := p.Receive(writeFile.iptIp)
+	icpkt := p.Receive(writeFile.iptIP)
 	fname, ok := icpkt.Contents.(string)
 	if !ok {
 		panic("Parameter (file name) not a string")
 	}
 	p.Discard(icpkt)
-	p.Close(writeFile.iptIp)
+	p.Close(writeFile.iptIP)
 
 	f, err := os.Create(fname)
 	if err != nil {

--- a/components/subnets/go.mod
+++ b/components/subnets/go.mod
@@ -1,0 +1,3 @@
+module gofbp/components/subnets
+
+go 1.16

--- a/components/subnets/sssubnet1.go
+++ b/components/subnets/sssubnet1.go
@@ -1,3 +1,4 @@
+/*Package subnets implements FBP subnet processing*/
 package subnets
 
 import (

--- a/components/subnets/subnet1.go
+++ b/components/subnets/subnet1.go
@@ -25,3 +25,5 @@ func (subnet *Subnet1) Execute(p *core.Process) {
 
 	net.Run()
 }
+
+//  NAME->0(proc1 SubIn)1.OUT -> IN.0(Proc2 WriteToConsole1)1.OUT -> NAME.0(proc3 SubOut);

--- a/components/testrtn/go.mod
+++ b/components/testrtn/go.mod
@@ -1,0 +1,3 @@
+module components/testrtn
+
+go 1.16

--- a/components/testrtn/prefix.go
+++ b/components/testrtn/prefix.go
@@ -8,7 +8,7 @@ import (
 
 type Prefix struct {
 	ipt   core.InputConn
-	iptIp core.InputConn
+	iptIP core.InputConn
 	out   core.OutputConn
 }
 
@@ -18,17 +18,17 @@ func (prefix *Prefix) Setup(p *core.Process) {
 
 	prefix.out = p.OpenOutPort("OUT")
 
-	prefix.iptIp = p.OpenInPort("PARAM")
+	prefix.iptIP = p.OpenInPort("PARAM")
 }
 
 func (prefix *Prefix) Execute(p *core.Process) {
 
-	icpkt := p.Receive(prefix.iptIp)
+	icpkt := p.Receive(prefix.iptIP)
 	param := icpkt.Contents.(string)
 
 	p.Discard(icpkt)
 
-	p.Close(prefix.iptIp)
+	p.Close(prefix.iptIP)
 
 	for {
 		var pkt = p.Receive(prefix.ipt)

--- a/components/testrtn/selector.go
+++ b/components/testrtn/selector.go
@@ -9,7 +9,7 @@ import (
 
 type Selector struct {
 	ipt   core.InputConn
-	iptIp core.InputConn
+	iptIP core.InputConn
 	out1  core.OutputConn
 	out2  core.OutputConn
 }
@@ -22,20 +22,20 @@ func (selector *Selector) Setup(p *core.Process) {
 
 	selector.out2 = p.OpenOutPortOptional("REJ")
 
-	selector.iptIp = p.OpenInPort("PARAM")
+	selector.iptIP = p.OpenInPort("PARAM")
 }
 
 func (Selector) MustRun() {}
 
 func (selector *Selector) Execute(p *core.Process) {
 
-	icpkt := p.Receive(selector.iptIp)
+	icpkt := p.Receive(selector.iptIP)
 	param := icpkt.Contents.(string)
 	i := len(param)
 
 	p.Discard(icpkt)
 
-	p.Close(selector.iptIp)
+	p.Close(selector.iptIP)
 
 	for {
 		var pkt = p.Receive(selector.ipt)

--- a/components/testrtn/sender.go
+++ b/components/testrtn/sender.go
@@ -1,22 +1,26 @@
+/*Package testrtn tests gofbp code.*/
 package testrtn
 
 import (
 	//"fmt"
 	"strconv"
-
+	
 	"github.com/jpaulm/gofbp/core"
 )
 
+/*Sender type defines ipt and opt for process send*/
 type Sender struct {
 	ipt core.InputConn
 	opt core.OutputConn
 }
 
+/*Setup function initializes a source process.*/
 func (sender *Sender) Setup(p *core.Process) {
 	sender.ipt = p.OpenInPort("COUNT")
 	sender.opt = p.OpenOutPort("OUT")
 }
 
+/*Execute function launches a source process.*/
 func (sender *Sender) Execute(p *core.Process) {
 	
 	icpkt := p.Receive(sender.ipt)

--- a/core/component.go
+++ b/core/component.go
@@ -1,10 +1,13 @@
+/*Package core implements gofbp's run time engine.*/
 package core
 
+/*The Component interface implements component Setup and Execute methods.*/
 type Component interface {
 	Setup(*Process)
 	Execute(*Process)
 }
 
+/*The ComponentWithMustRun interface implements the MustRun method.*/
 type ComponentWithMustRun interface {
 	Component
 	MustRun() bool

--- a/core/go.mod
+++ b/core/go.mod
@@ -1,0 +1,3 @@
+module core
+
+go 1.16

--- a/core/subnet_support.go
+++ b/core/subnet_support.go
@@ -7,7 +7,7 @@ import (
 
 type SubIn struct {
 	//ipt   InputConn
-	iptIp InputConn
+	iptIP InputConn
 	out   OutputConn
 	eipt  InputConn
 }
@@ -22,12 +22,12 @@ func (subIn *SubIn) Setup(p *Process) {
 
 	subIn.out = p.OpenOutPort("OUT")
 
-	subIn.iptIp = p.OpenInPort("NAME")
+	subIn.iptIP = p.OpenInPort("NAME")
 }
 
 func (subIn *SubIn) Execute(p *Process) {
 
-	icpkt := p.Receive(subIn.iptIp)
+	icpkt := p.Receive(subIn.iptIP)
 	param := icpkt.Contents.(string)
 
 	p.Discard(icpkt)
@@ -56,7 +56,7 @@ func (subIn *SubIn) Execute(p *Process) {
 
 func (subIn *SubInSS) Execute(p *Process) {
 
-	icpkt := p.Receive(subIn.iptIp)
+	icpkt := p.Receive(subIn.iptIP)
 	param := icpkt.Contents.(string)
 
 	p.Discard(icpkt)
@@ -92,7 +92,7 @@ func (subIn *SubInSS) Execute(p *Process) {
 
 type SubOut struct {
 	ipt   InputConn
-	iptIp InputConn
+	iptIP InputConn
 	eopt  OutputConn
 }
 
@@ -104,14 +104,14 @@ func (subOut *SubOut) Setup(p *Process) {
 
 	subOut.ipt = p.OpenInPort("IN")
 
-	subOut.iptIp = p.OpenInPort("NAME")
+	subOut.iptIP = p.OpenInPort("NAME")
 }
 
 //func (SubOut) MustRun() {}
 
 func (subOut *SubOut) Execute(p *Process) {
 
-	icpkt := p.Receive(subOut.iptIp)
+	icpkt := p.Receive(subOut.iptIP)
 	param := icpkt.Contents.(string)
 
 	p.Discard(icpkt)
@@ -137,7 +137,7 @@ func (subOut *SubOut) Execute(p *Process) {
 }
 func (subOut *SubOutSS) Execute(p *Process) {
 
-	icpkt := p.Receive(subOut.iptIp)
+	icpkt := p.Receive(subOut.iptIP)
 	param := icpkt.Contents.(string)
 
 	p.Discard(icpkt)

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,18 @@
 module github.com/jpaulm/gofbp
 
+replace github.com/jpaulm/gofbp/components/io => ./components/io
+
+replace github.com/jpaulm/gofbp/core => ./core
+
+replace github.com/jpaulm/gofbp/components/subnets => ./components/subnets
+
+replace github.com/jpaulm/gofbp/components/testrtn => ./components/testrtn
+
 go 1.17
+
+require (
+	github.com/jpaulm/gofbp/components/io v0.0.0-00010101000000-000000000000
+	github.com/jpaulm/gofbp/components/subnets v0.0.0-00010101000000-000000000000
+	github.com/jpaulm/gofbp/components/testrtn v0.0.0-00010101000000-000000000000
+	github.com/jpaulm/gofbp/core v0.0.0-00010101000000-000000000000
+)


### PR DESCRIPTION
Setting up modules allows for accessing github gofbp modules remotely from user's source trees.    For instance, the github.com/tyoung3/sw  project could then access gofbp/components/testrtn without needing to clone the gofbp source tree.

A few functions were documented according to the GOLANG convention (Comments immediately preceding the type/function/method declaration.

The PARAMS.xml file was copied to README.md

iptIp was changed to iptIP to conform to GOLANG convention.